### PR TITLE
Fix Bennett support build Circlet main stat to HP%

### DIFF
--- a/src/data/build.js
+++ b/src/data/build.js
@@ -3104,7 +3104,7 @@ export const builds = {
         mainStats: {
           sands: 'Energy Recharge',
           goblet: 'HP%',
-          circlet: 'Flat HP',
+          circlet: 'HP%',
         },
         subStats: ['Energy Recharge', 'HP%', 'Flat HP'],
         talent: ['Burst', 'Skill', 'Normal Attack'],


### PR DESCRIPTION
[Bennett's support build](https://paimon.moe/characters/bennett#support) had the Circlet's recommended main stat typoed as Flat HP which a Circlet cannot have. This fixes it to HP%.